### PR TITLE
Docker: Point at correct source

### DIFF
--- a/example/packer-docker/group_vars/chatsrv.yml
+++ b/example/packer-docker/group_vars/chatsrv.yml
@@ -30,5 +30,4 @@ nginx_configs:
 
 simplechat:
   install:
-    dest: /tmp/simple-chat
-    synchronize: false
+    source: /tmp/simple-chat.tar.gz

--- a/packer-docker.json
+++ b/packer-docker.json
@@ -20,8 +20,8 @@
     },
     {
         "type": "file",
-        "source": "simple-chat/simple-chat",
-        "destination": "/tmp/simple-chat"
+        "source": "simple-chat/simple-chat.tar.gz",
+        "destination": "/tmp/simple-chat.tar.gz"
     },
     {
         "type": "file",


### PR DESCRIPTION
Is currently defaulted to `/vagrant/simple-chat/simple-chat.tar.gz`,
which doesn't exist based on docker's packer file.
